### PR TITLE
Allow clients to join after a game has started

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,5 @@
+alias BullServer.Games
+alias BullServer.Games.Game
+
+alias BullServerWeb.GameChannel
+alias BullServerWeb.Presence

--- a/lib/bull_server/games.ex
+++ b/lib/bull_server/games.ex
@@ -135,6 +135,16 @@ defmodule BullServer.Games do
   end
 
   @doc """
+  Gets the rejoin key for a user.
+  """
+  @spec key(game_id :: String.t, player_name :: String.t) :: String.t
+  def key(game_id, player_name) do
+    game_id
+    |> get()
+    |> Game.key(player_name)
+  end
+
+  @doc """
   List all games in memory.
   """
   @spec list() :: map

--- a/lib/bull_server/games.ex
+++ b/lib/bull_server/games.ex
@@ -19,6 +19,31 @@ defmodule BullServer.Games do
   end
 
   @doc """
+  Returns whether or not a player can join a game.
+  """
+  @spec can_join?(game_id :: String.t, player_name :: String.t, key :: String.t) :: {:ok, nil} | {:error, String.t}
+  def can_join?(game_id, player_name, key) do
+    with game when is_pid(game) <- get(game_id),
+         false <- Game.has_started?(game)
+    do
+      {:ok, nil}
+    else
+      nil -> {:error, :bad_id}
+      true -> authorize(game_id, player_name, key)
+    end
+  end
+
+  @spec authorize(game_id :: String.t, player_name :: String.t, key :: String.t) :: {:ok, nil} | {:error, atom}
+  defp authorize(_, _, nil), do: {:error, :started}
+  defp authorize(game_id, player_name, key) do
+    game = get(game_id)
+    case Game.key(game, player_name) do
+      ^key -> {:ok, nil}
+      _ -> {:error, :bad_key}
+    end
+  end
+
+  @doc """
   Clears a game from memory.
   """
   @spec clear(game_id :: String.t) :: :ok

--- a/lib/bull_server/games/game.ex
+++ b/lib/bull_server/games/game.ex
@@ -61,6 +61,14 @@ defmodule BullServer.Games.Game do
   end
 
   @doc """
+  Gets the rejoin key for a player.
+  """
+  @spec key(game :: pid, player_name :: String.t) :: String.t
+  def key(game, player_name) do
+    Agent.get(game, &get_in(&1, [:players, player_name]))
+  end
+
+  @doc """
   Gets the next stage of the game.
   """
   @spec next_stage(game :: pid) :: atom

--- a/lib/bull_server_web/channels/game_channel.ex
+++ b/lib/bull_server_web/channels/game_channel.ex
@@ -14,9 +14,14 @@ defmodule BullWebServer.GameChannel do
     send(self(), :create_game)
     {:ok, socket}
   end
-  def join("game:" <> _game_id, _message, socket) do
-    send(self(), :after_join)
-    {:ok, socket}
+  def join("game:" <> game_id, _message, %{assigns: assigns} = socket) do
+    player_name = Map.get(assigns, :name)
+    key = Map.get(assigns, :key)
+
+    with {:ok, _} <- Games.can_join?(game_id, player_name, key) do
+      send(self(), :after_join)
+      {:ok, socket}
+    end
   end
 
   @doc """

--- a/lib/bull_server_web/channels/game_channel.ex
+++ b/lib/bull_server_web/channels/game_channel.ex
@@ -126,5 +126,5 @@ defmodule BullWebServer.GameChannel do
 
   defp game_id(%{topic: "game:" <> game_id}), do: game_id
 
-  defp player_name(%{assigns: %{player_name: name}}), do: name
+  defp player_name(%{assigns: %{name: name}}), do: name
 end

--- a/lib/bull_server_web/channels/user_socket.ex
+++ b/lib/bull_server_web/channels/user_socket.ex
@@ -19,6 +19,14 @@ defmodule BullServerWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
+  def connect(%{"name" => name, "key" => key}, socket) do
+    transformed =
+      socket
+      |> assign(:name, name)
+      |> assign(:key, key)
+
+    {:ok, transformed}
+  end
   def connect(%{"name" => name}, socket) do
     {:ok, assign(socket, :name, name)}
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,13 +1,13 @@
 %{
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.14.0", "1a019a2e51d5ad3d126efe166dcdf6563768e5d06c32a99ad2281a1fa94b4c72", [:mix], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.0", "1c01124caa1b4a7af46f2050ff11b267baa3edb441b45dbf243e979cd4c5891b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.4.4", "279b547662272cd835a8ca089717201dd3be51bb4705354eaf1b0346744acc82", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.0", "1c01124caa1b4a7af46f2050ff11b267baa3edb441b45dbf243e979cd4c5891b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.4.4", "279b547662272cd835a8ca089717201dd3be51bb4705354eaf1b0346744acc82", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
#1 - If a user leaves after a game has started, it should be possible for them to rejoin.
- [ ] Provide a secret key to each client at the start of the game
- [ ] Allow the user to rejoin the game if they provide the same name and the secret key
- [ ] Send the current game state to the client when they join again